### PR TITLE
Add custom join_path for compatibility with windows users

### DIFF
--- a/mdsuite/calculators/einstein_helfand_ionic_conductivity.py
+++ b/mdsuite/calculators/einstein_helfand_ionic_conductivity.py
@@ -23,6 +23,7 @@ from tqdm import tqdm
 
 # Import MDSuite modules
 import mdsuite.utils.meta_functions as meta_functions
+from mdsuite.utils.meta_functions import join_path
 from mdsuite.calculators.calculator import Calculator
 from mdsuite.utils.units import elementary_charge, boltzmann_constant
 from mdsuite.database.database import Database
@@ -222,7 +223,7 @@ class EinsteinHelfandIonicConductivity(Calculator):
                       self.parent.temperature * boltzmann_constant
         prefactor = numerator / denominator
 
-        group = os.path.join(self.loaded_property, self.loaded_property)
+        group = join_path(self.loaded_property, self.loaded_property)
         dipole_msd_array = self.msd_operation_EH(group=group)
         dipole_msd_array /= int(self.n_batches['Parallel'] * self.batch_loop)  # scale by the number of batches
         dipole_msd_array *= prefactor

--- a/mdsuite/database/database.py
+++ b/mdsuite/database/database.py
@@ -6,6 +6,7 @@ import h5py as hf
 import os
 import numpy as np
 from typing import TextIO
+from mdsuite.utils.meta_functions import join_path
 
 from mdsuite.utils.exceptions import *
 
@@ -204,7 +205,7 @@ class Database:
                 architecture[group] = structure[group]
             else:
                 for subgroup in structure[group]:
-                    db_path = os.path.join(group, subgroup)
+                    db_path = join_path(group, subgroup)
                     architecture[db_path] = structure[group][subgroup]
 
         return architecture
@@ -305,7 +306,7 @@ class Database:
         memory_database = {}
         for item in database:
             for ds in database[item]:
-                memory_database[os.path.join(item, ds)] = database[item][ds].nbytes
+                memory_database[join_path(item, ds)] = database[item][ds].nbytes
 
         return memory_database
 

--- a/mdsuite/experiment/experiment.py
+++ b/mdsuite/experiment/experiment.py
@@ -26,6 +26,7 @@ from mdsuite.calculators.computations_dict import dict_classes_computations
 from mdsuite.transformations.transformation_dict import transformations_dict
 from mdsuite.file_io.file_io_dict import dict_file_io
 from mdsuite.utils.units import units_dict
+from mdsuite.utils.meta_functions import join_path
 from mdsuite.utils.exceptions import *
 from mdsuite.database.database import Database
 from mdsuite.file_io.file_read import FileProcessor
@@ -593,7 +594,7 @@ class Experiment:
 
             with hf.File(os.path.join(self.database_path, 'database.hdf5'), "r+") as database:
                 for item in list(species):
-                    path = os.path.join(item, identifier)
+                    path = join_path(item, identifier)
 
                     # Unwrap the positions if they need to be unwrapped
                     if identifier == "Unwrapped_Positions" and "Unwrapped_Positions" not in database[item]:

--- a/mdsuite/file_io/trajectory_files.py
+++ b/mdsuite/file_io/trajectory_files.py
@@ -12,6 +12,7 @@ from typing import TextIO
 import h5py as hf
 import numpy as np
 from tqdm import tqdm
+from mdsuite.utils.meta_functions import join_path
 
 from mdsuite.file_io.file_read import FileProcessor
 
@@ -113,7 +114,7 @@ class TrajectoryFile(FileProcessor, metaclass=abc.ABCMeta):
                                   self.header_lines for i in range(batch_size)]).flatten()
             length = len(self.project.species[item]['indices'])
             for observable in self.project.property_groups:
-                path = os.path.join(item, observable)
+                path = join_path(item, observable)
                 columns = self.project.property_groups[observable]
                 structure[path] = {'indices': positions, 'columns': columns, 'length': length}
 

--- a/mdsuite/utils/meta_functions.py
+++ b/mdsuite/utils/meta_functions.py
@@ -24,6 +24,26 @@ from mdsuite.utils.exceptions import NoGPUInSystem
 from typing import Callable
 
 
+def join_path(a, b):
+    """Join a and b and make sure to use forward slashes
+
+    Parameters
+    ----------
+    a: str
+    b: str
+
+    Returns
+    -------
+    str: joined path with forced forward slashes
+
+    Notes
+    -----
+    h5py 3.1.0 on windows relies on forward slashes but os.path.join returns backward slashes.
+    Here we replace them to enable MDSuite for Windows users.
+
+    """
+    return os.path.join(a, b).replace("\\","/")
+
 def get_dimensionality(box: list) -> int:
     """
     Calculate the dimensionality of the system box


### PR DESCRIPTION
This should fix the issue with h5py databases on Windows.
Furthermore we should investigate the usage of `group = join_path(self.loaded_property, self.loaded_property)` in the _einstein_helfand_ionic_conductivity.py_ because it is the only calculator where it uses the join_path.