### PR TITLE
moved dictionary db results to computations_dict

### DIFF
--- a/mdsuite/calculators/computations_dict.py
+++ b/mdsuite/calculators/computations_dict.py
@@ -5,6 +5,7 @@ Summary
 -------
 """
 
+from mdsuite.calculators.angular_distribution_function import AngularDistributionFunction
 from mdsuite.calculators.coordination_number_calculation import CoordinationNumbers
 from mdsuite.calculators.einstein_diffusion_coefficients import EinsteinDiffusionCoefficients
 from mdsuite.calculators.einstein_helfand_ionic_conductivity import EinsteinHelfandIonicConductivity
@@ -16,11 +17,10 @@ from mdsuite.calculators.green_kubo_ionic_conductivity import GreenKuboIonicCond
 from mdsuite.calculators.green_kubo_thermal_conductivity import GreenKuboThermalConductivity
 from mdsuite.calculators.green_kubo_viscosity import GreenKuboViscosity
 from mdsuite.calculators.kirkwood_buff_integrals import KirkwoodBuffIntegral
+from mdsuite.calculators.nernst_einstein_ionic_conductivity import NernstEinsteinIonicConductivity
 from mdsuite.calculators.potential_of_mean_force import PotentialOfMeanForce
 from mdsuite.calculators.radial_distribution_function import RadialDistributionFunction
 from mdsuite.calculators.structure_factor import StructureFactor
-from mdsuite.calculators.angular_distribution_function import AngularDistributionFunction
-from mdsuite.calculators.nernst_einstein_ionic_conductivity import NernstEinsteinIonicConductivity
 
 dict_classes_computations = {
     'EinsteinDiffusionCoefficients': EinsteinDiffusionCoefficients,
@@ -39,4 +39,17 @@ dict_classes_computations = {
     'GreenKuboViscosity': GreenKuboViscosity,
     'AngularDistributionFunction': AngularDistributionFunction,
     'NernstEinsteinIonicConductivity': NernstEinsteinIonicConductivity
+}
+
+dict_classes_db = {
+    'diffusion_coefficients': {'einstein_diffusion_coefficients': {'Singular': {}, 'Distinct': {}},
+                               'Green_Kubo_Diffusion': {'Singular': {}, 'Distinct': {}}},
+    'ionic_conductivity': {},
+    'thermal_conductivity': {},
+    'coordination_numbers': {'Coordination_Numbers': {}},
+    'potential_of_mean_force_values': {'Potential_of_Mean_Force': {}},
+    'radial_distribution_function': {},
+    'kirkwood_buff_integral': {},
+    'structure_factor': {},
+    'viscosity': {}
 }

--- a/mdsuite/experiment/experiment.py
+++ b/mdsuite/experiment/experiment.py
@@ -22,7 +22,7 @@ from tqdm import tqdm
 import importlib.resources
 
 from mdsuite import data as static_data
-from mdsuite.calculators.computations_dict import dict_classes_computations
+from mdsuite.calculators.computations_dict import dict_classes_computations, dict_classes_db
 from mdsuite.transformations.transformation_dict import transformations_dict
 from mdsuite.file_io.file_io_dict import dict_file_io
 from mdsuite.utils.units import units_dict
@@ -107,15 +107,7 @@ class Experiment:
         self.kirkwood_buff_integral_state = False  # Set true if it has been calculated
         self.structure_factor_state = False
 
-        self.results = [
-            'diffusion_coefficients',
-            'ionic_conductivity',
-            'thermal_conductivity',
-            'coordination_numbers',
-            'potential_of_mean_force_values',
-            'radial_distribution_function',
-            'kirkwood_buff_integral'
-        ]
+        self.results = list(dict_classes_db.keys())
 
         # Memory properties
         self.memory_requirements = {}
@@ -497,16 +489,7 @@ class Experiment:
 
         # Instantiate YAML file for system properties
         with open(os.path.join(self.database_path, 'system_properties.yaml'), 'w') as f:
-            data = {'diffusion_coefficients': {'einstein_diffusion_coefficients': {'Singular': {}, 'Distinct': {}},
-                                               'Green_Kubo_Diffusion': {'Singular': {}, 'Distinct': {}}},
-                    'ionic_conductivity': {},
-                    'thermal_conductivity': {},
-                    'coordination_numbers': {'Coordination_Numbers': {}},
-                    'potential_of_mean_force_values': {'Potential_of_Mean_Force': {}},
-                    'radial_distribution_function': {},
-                    'kirkwood_buff_integral': {},
-                    'structure_factor': {},
-                    'viscosity': {}}
+            data = dict_classes_db
 
             yaml.dump(data, f)
 


### PR DESCRIPTION
As discussed in issue #116 , I have merged the dictionaries referrign to those results into one and moved it to the `computations_dict`. 
New users will only to create a calculator file, and then modify the two dictionaries in `computations_dict.py`