### PR TITLE
Remove not required packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,6 @@ setuptools.setup(
     install_requires=['tensorflow',
                       'h5py',
                       'pysmiles',
-                      'numpy',
                       'matplotlib',
                       'scipy',
                       'tqdm',


### PR DESCRIPTION
I've looked through the list of required packages and found that we don't require:
- seaborn
- diagrams
- dask
- ipython